### PR TITLE
fix: Docker version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
     branches: [ main ]
 
+
 jobs:
   Formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # Recommended to use latest stable v4 or v3
+      - uses: actions/checkout@v4
       - name: Formatting
-        uses: github/super-linter@v5 # Recommended to use latest stable v5 or v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
@@ -22,71 +23,76 @@ jobs:
   Linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4 # Recommended to use latest stable v4 or v3
+    - uses: actions/checkout@v4
     - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v2 # Recommended to use latest stable v2
+      uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--lint"
 
-  Unit-Tests: # Renamed this job slightly for clarity and moved it up
+  Unit-Tests:
       runs-on: ubuntu-latest
-      needs: [Linting, Formatting]
+      needs: [Linting, Formatting] 
       steps:
-        - uses: actions/checkout@v4 # Use latest stable version
+        - uses: actions/checkout@v4
         - name: Set up Python
-          uses: actions/setup-python@v5 # Use latest stable version
+          uses: actions/setup-python@v5
           with:
-            # IMPORTANT: Match the Python version you develop/test with.
-            # If you decided on Python 3.11 as a stable base for your Snakemake envs,
-            # it's usually best to test your package on that version too.
-            python-version: '3.12' # Changed from '3.12' if you are targeting 3.11
+            python-version: '3.12' 
 
-        - name: Install dependencies
+        - name: Install dependencies and build package
           run: |
             python -m pip install --upgrade pip
-            # Install your package in editable mode.
-            # This implicitly installs dependencies from pyproject.toml -> project.dependencies
+            # Install build-time dependencies (tomli/tomllib for setup.py)
+            pip install tomli # for python < 3.11, harmless on 3.11+
+            # This step executes setup.py, which modifies __init__.py
             pip install -e .
-            # Explicitly list additional test-specific dependencies not in project.dependencies
-            # These are typically development dependencies only for testing.
-            pip install unittest-xml-reporting # For JUnit XML output (optional)
-            # You might not need to explicitly install PyGithub, pydot, configparser, appdirs here
-            # if they are correctly listed in your pyproject.toml's [project].dependencies
-            # and pip install -e . handles them. If not, then keep them.
-            # Example if needed: pip install PyGithub pydot configparser appdirs
+            # Install test-specific dependencies
+            pip install unittest-xml-reporting
 
         - name: Run unit tests
           run: |
-            # If your test file is directly in the root and named test_*.py:
-            python -m unittest discover -s . -p 'test_*.py' -v
-            # If your tests are in a 'tests' directory as commonly recommended:
-            # python -m unittest discover -s tests -p 'test_*.py' -v
-          # You typically don't need GITHUB_TOKEN for unit tests, as you're mocking network calls.
-          # Only include if you have integration tests that truly hit the GitHub API.
-          # env:
-          #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            python -m unittest discover -s tests -p 'test_*.py' -v # Assuming 'tests' directory
 
-  Testing-workflow: # Main Snakemake workflow testing job
+  # Renamed to make it clearer what this job does
+  End-to-End-Workflow-Test:
     runs-on: ubuntu-latest
+    # This job needs Unit-Tests to pass, as your main code logic depends on it.
     needs:
-      - Linting
-      - Formatting
+      - Unit-Tests
     steps:
-    - uses: actions/checkout@v4 # Use latest stable version
-    - name: Test workflow
-      uses: snakemake/snakemake-github-action@v2 # Use latest stable version
+    - uses: actions/checkout@v4 # Always checkout the code in each job
+
+    - name: Set up Python for Snakemake workflow
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11' # Match your workflow's Python env
+
+    - name: Install dependencies and Snakemake
+      run: |
+        python -m pip install --upgrade pip
+        # Install your package in editable mode. This triggers setup.py.
+        pip install -e .
+        # Install Snakemake explicitly in this CI environment if not handled by action itself
+        # The snakemake-github-action typically handles Snakemake installation,
+        # but if your workflow relies on a specific version that isn't handled
+        # by the action's 'snakemake-version' input, you might need it here.
+        # However, the 'snakemake-github-action' does this for you, so usually NOT needed here.
+        # pip install snakemake==8.25.5
+
+    - name: Test workflow (Snakemake)
+      uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        snakemake-version: 8.25.5
+        snakemake-version: 8.25.5 # Forces the specific Snakemake version
         args: "--use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
 
-    - name: Test report
-      uses: snakemake/snakemake-github-action@v2 # Use latest stable version
+    - name: Generate Test Report
+      uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        snakemake-version: 8.25.5
+        snakemake-version: 8.25.5 # Forces the specific Snakemake version
         args: "--report report.zip"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          python -m unittest discover -s tests -p 'test_*.py' -v
+          python -m unittest discover -s . -p 'test_*.py' -v
 
   End-to-End-Workflow-Test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11' # Or whatever you're using.
+        python-version: '3.12'
     - name: Install gpsw for linting
       run: |
         python -m pip install --upgrade pip
@@ -41,7 +41,7 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        snakemake-version: 8.25.5 # Forces the specific Snakemake version
+        snakemake-version: 8.25.5
         args: "--lint"
 
   Unit-Tests:
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies and build package
         run: |
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python for Snakemake workflow
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies and Snakemake
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Add this step if Super-Linter needs to import your package
-      #- name: Install gpsw for formatting
-      #  run: |
-      #    python -m pip install --upgrade pip
-      #    pip install -e .
       - name: Formatting
         uses: github/super-linter@v5
         env:
@@ -27,22 +22,26 @@ jobs:
   Linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-    - name: Install gpsw for linting
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e . # Install the package so Snakemake can find it for linting
-    - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v2
-      with:
-        directory: .test
-        snakefile: workflow/Snakefile
-        snakemake-version: 8.25.5
-        args: "--lint"
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12' # Keep consistent with your project's requirement
+      - name: Install gpsw for linting
+        run: |
+          python -m pip install --upgrade pip
+          # Ensure tomli/tomllib are available for setup.py
+          pip install tomli # For Python < 3.11, harmless on 3.11+
+          pip install -e . # Install the package and its dependencies
+      - name: Lint workflow
+        uses: snakemake/snakemake-github-action@v2
+        with:
+          directory: .test
+          snakefile: workflow/Snakefile
+          snakemake-version: 8.25.5
+          args: "--lint"
+        env: 
+          PYTHONPATH: ${{ github.workspace }}/src # Adds 'src' folder to Python path
 
   Unit-Tests:
     runs-on: ubuntu-latest
@@ -57,12 +56,13 @@ jobs:
       - name: Install dependencies and build package
         run: |
           python -m pip install --upgrade pip
+          pip install tomli # Ensure tomli/tomllib for setup.py
           pip install -e .
           pip install unittest-xml-reporting
 
       - name: Run unit tests
         run: |
-          python -m unittest discover -s . -p 'test_*.py' -v
+          python -m unittest discover -s tests -p 'test_*.py' -v
 
   End-to-End-Workflow-Test:
     runs-on: ubuntu-latest
@@ -79,6 +79,7 @@ jobs:
       - name: Install dependencies and Snakemake
         run: |
           python -m pip install --upgrade pip
+          pip install tomli # Ensure tomli/tomllib for setup.py
           pip install -e .
 
       - name: Test workflow (Snakemake)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     branches: [ main ]
 
-
 jobs:
   Formatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Add this step if Super-Linter needs to import your package
+      #- name: Install gpsw for formatting
+      #  run: |
+      #    python -m pip install --upgrade pip
+      #    pip install -e .
       - name: Formatting
         uses: github/super-linter@v5
         env:
@@ -24,75 +28,71 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11' # Or whatever you're using.
+    - name: Install gpsw for linting
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e . # Install the package so Snakemake can find it for linting
     - name: Lint workflow
       uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile
+        snakemake-version: 8.25.5 # Forces the specific Snakemake version
         args: "--lint"
 
   Unit-Tests:
-      runs-on: ubuntu-latest
-      needs: [Linting, Formatting] 
-      steps:
-        - uses: actions/checkout@v4
-        - name: Set up Python
-          uses: actions/setup-python@v5
-          with:
-            python-version: '3.12' 
+    runs-on: ubuntu-latest
+    needs: [Linting, Formatting]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-        - name: Install dependencies and build package
-          run: |
-            python -m pip install --upgrade pip
-            # Install build-time dependencies (tomli/tomllib for setup.py)
-            pip install tomli # for python < 3.11, harmless on 3.11+
-            # This step executes setup.py, which modifies __init__.py
-            pip install -e .
-            # Install test-specific dependencies
-            pip install unittest-xml-reporting
+      - name: Install dependencies and build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install unittest-xml-reporting
 
-        - name: Run unit tests
-          run: |
-            python -m unittest discover -s tests -p 'test_*.py' -v # Assuming 'tests' directory
+      - name: Run unit tests
+        run: |
+          python -m unittest discover -s . -p 'test_*.py' -v
 
-  # Renamed to make it clearer what this job does
   End-to-End-Workflow-Test:
     runs-on: ubuntu-latest
-    # This job needs Unit-Tests to pass, as your main code logic depends on it.
     needs:
       - Unit-Tests
     steps:
-    - uses: actions/checkout@v4 # Always checkout the code in each job
+      - uses: actions/checkout@v4
 
-    - name: Set up Python for Snakemake workflow
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11' # Match your workflow's Python env
+      - name: Set up Python for Snakemake workflow
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-    - name: Install dependencies and Snakemake
-      run: |
-        python -m pip install --upgrade pip
-        # Install your package in editable mode. This triggers setup.py.
-        pip install -e .
-        # Install Snakemake explicitly in this CI environment if not handled by action itself
-        # The snakemake-github-action typically handles Snakemake installation,
-        # but if your workflow relies on a specific version that isn't handled
-        # by the action's 'snakemake-version' input, you might need it here.
-        # However, the 'snakemake-github-action' does this for you, so usually NOT needed here.
-        # pip install snakemake==8.25.5
+      - name: Install dependencies and Snakemake
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
 
-    - name: Test workflow (Snakemake)
-      uses: snakemake/snakemake-github-action@v2
-      with:
-        directory: .test
-        snakefile: workflow/Snakefile
-        snakemake-version: 8.25.5 # Forces the specific Snakemake version
-        args: "--use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
+      - name: Test workflow (Snakemake)
+        uses: snakemake/snakemake-github-action@v2
+        with:
+          directory: .test
+          snakefile: workflow/Snakefile
+          snakemake-version: 8.25.5
+          args: "--use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
 
-    - name: Generate Test Report
-      uses: snakemake/snakemake-github-action@v2
-      with:
-        directory: .test
-        snakefile: workflow/Snakefile
-        snakemake-version: 8.25.5 # Forces the specific Snakemake version
-        args: "--report report.zip"
+      - name: Generate Test Report
+        uses: snakemake/snakemake-github-action@v2
+        with:
+          directory: .test
+          snakefile: workflow/Snakefile
+          snakemake-version: 8.25.5
+          args: "--report report.zip"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12' # Keep consistent with your project's requirement
+          python-version: '3.12'
       - name: Install gpsw for linting
         run: |
           python -m pip install --upgrade pip
-          # Ensure tomli/tomllib are available for setup.py
-          pip install tomli # For Python < 3.11, harmless on 3.11+
+
           pip install -e . # Install the package and its dependencies
       - name: Lint workflow
         uses: snakemake/snakemake-github-action@v2
@@ -40,7 +39,7 @@ jobs:
           snakefile: workflow/Snakefile
           snakemake-version: 8.25.5
           args: "--lint"
-        env: 
+        env:
           PYTHONPATH: ${{ github.workspace }}/src # Adds 'src' folder to Python path
 
   Unit-Tests:
@@ -89,6 +88,8 @@ jobs:
           snakefile: workflow/Snakefile
           snakemake-version: 8.25.5
           args: "--use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
+        env: # <--- IMPORTANT: Add PYTHONPATH here for the Snakemake execution
+          PYTHONPATH: ${{ github.workspace }}/src
 
       - name: Generate Test Report
         uses: snakemake/snakemake-github-action@v2
@@ -97,3 +98,5 @@ jobs:
           snakefile: workflow/Snakefile
           snakemake-version: 8.25.5
           args: "--report report.zip"
+        env: # <--- IMPORTANT: Add PYTHONPATH here for the Snakemake report generation as well
+          PYTHONPATH: ${{ github.workspace }}/src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpsw"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     { name="Niek Wit", email="nw416@cam.ac.uk" },
 ]
@@ -32,4 +32,9 @@ gpsw = "gpsw.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"} 
-packages = ["gpsw"] 
+packages = ["gpsw"]
+
+[tool.gpsw]
+# Some GPSW versions have no change in the software environment.
+# So an older container image can be used to save time and space.
+container_image_version = "0.6.0"

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,26 @@ def read_pyproject_toml():
 # Function to write versions to __init__.py
 def write_version_info(package_name, version, container_image_version):
     init_file = Path(__file__).parent / "src" / package_name / "__init__.py"
-    with open(init_file, "a") as f:  # Use "a" (append) or "w" (write) carefully
-        f.write(f"\n__container_image_version__ = '{container_image_version}'\n")
+
+    # Read existing content
+    content = ""
+    if init_file.exists():
+        with open(init_file, "r") as f:
+            content = f.read()
+
+    # Check if __container_image_version__ already exists
+    if "__container_image_version__" not in content:
+        with open(init_file, "a") as f:
+            f.write(f"\n__container_image_version__ = '{container_image_version}'\n")
+    else:
+        # Update existing line
+        import re
+
+        pattern = r'__container_image_version__\s*=\s*[\'"][^\'"]*[\'"]'
+        replacement = f"__container_image_version__ = '{container_image_version}'"
+        content = re.sub(pattern, replacement, content)
+        with open(init_file, "w") as f:
+            f.write(content)
     print(
         f"Injected __container_image_version__={container_image_version} into {init_file}"
     )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+import setuptools
+import tomllib  # For Python >= 3.11
+from pathlib import Path
+
+
+# Function to read pyproject.toml
+def read_pyproject_toml():
+    pyproject_path = Path(__file__).parent / "pyproject.toml"
+    if not pyproject_path.exists():
+        raise FileNotFoundError(f"{pyproject_path} not found.")
+    with open(pyproject_path, "rb") as f:
+        return tomllib.load(f)
+
+
+# Function to write versions to __init__.py
+def write_version_info(package_name, version, container_image_version):
+    init_file = Path(__file__).parent / "src" / package_name / "__init__.py"
+    with open(init_file, "a") as f:  # Use "a" (append) or "w" (write) carefully
+        f.write(f"\n__container_image_version__ = '{container_image_version}'\n")
+    print(
+        f"Injected __container_image_version__={container_image_version} into {init_file}"
+    )
+
+
+# Read data from pyproject.toml
+pyproject_data = read_pyproject_toml()
+package_name = pyproject_data["project"]["name"]
+package_version = pyproject_data["project"]["version"]
+container_image_version = (
+    pyproject_data.get("tool", {})
+    .get("gpsw", {})
+    .get("container_image_version", "unknown")
+)
+
+# Write to __init__.py
+write_version_info(package_name, package_version, container_image_version)
+
+# Use setuptools.setup() as usual
+setuptools.setup(
+    # setuptools will now read project details from pyproject.toml
+    # via build-backend = "setuptools.build_meta"
+)

--- a/src/gpsw/cli.py
+++ b/src/gpsw/cli.py
@@ -31,7 +31,7 @@ def fetch_code(args):
     # Download the tar.gz file in temp dir and untar to specified directory
     with tempfile.TemporaryDirectory(dir=args.directory) as tmpdirname:
         # Validate tag format to prevent URL manipulation
-        pattern = r"^[vV](0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
+        pattern = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
         if not re.match(pattern, tag):
             print(
                 f"Error: Invalid tag format '{tag}'. Tags should be in format vX.X.X (e.g., v1.0.0)."

--- a/src/gpsw/cli.py
+++ b/src/gpsw/cli.py
@@ -34,7 +34,7 @@ def fetch_code(args):
         pattern = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
         if not re.match(pattern, tag):
             print(
-                f"Error: Invalid tag format '{tag}'. Tags should be in format vX.X.X (e.g., v1.0.0)."
+                f"Error: Invalid tag format '{tag}'. Tags should be in format X.X.X (e.g., 1.0.0)."
             )
             sys.exit(1)
 

--- a/workflow/scripts/general_functions.smk
+++ b/workflow/scripts/general_functions.smk
@@ -4,6 +4,7 @@ import socket, platform
 from importlib.metadata import version, PackageNotFoundError
 
 import pandas as pd
+from gpsw import __container_image_version__
 
 from snakemake.logging import logger
 from snakemake.shell import shell
@@ -20,6 +21,7 @@ def get_package_version():
 
 # Workflow version
 VERSION = get_package_version()
+DOCKER_VERSION = __container_image_version__
 wrapper_version = "v5.2.1"
 
 ## This header can help with debugging, extend later with more info
@@ -82,6 +84,9 @@ logger.info("  Python:            " + str(sys.version.split(" ")[0]))
 logger.info("  Snakemake:         " + snakemake.__version__)
 logger.info("  GPSW:              " + VERSION)
 logger.info("  Wrapper:           " + wrapper_version)
+# if apptainer argument is used, print the version of the docker image
+
+logger.info("  Docker image:      " + DOCKER_VERSION)
 logger.info("  Command:           " + cmdline)
 logger.info("")
 

--- a/workflow/scripts/general_functions.smk
+++ b/workflow/scripts/general_functions.smk
@@ -16,7 +16,7 @@ def get_package_version():
     except PackageNotFoundError:
         # Package is not installed (e.g., running locally without installation)
         # For development purposes
-        return "v0.0.0-dev"
+        return "0.0.0-dev"
 
 
 # Workflow version


### PR DESCRIPTION
This pull request introduces several updates to enhance version management, improve logging, and refine tag validation. The most significant changes include adding a `container_image_version` field in `pyproject.toml`, implementing a mechanism to write this version to the `__init__.py` file, updating tag validation rules, and extending logging to include the Docker image version.

### Version Management Enhancements:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R36-R40): Added a new `container_image_version` field under `[tool.gpsw]` to specify the version of the container image. This allows using older container images when no software environment changes are required.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R1-R60): Introduced functionality to read the `container_image_version` from `pyproject.toml` and inject it into the `__init__.py` file as `__container_image_version__`. This ensures the version is accessible programmatically.

### Logging Improvements:
* `workflow/scripts/general_functions.smk`:
  * Imported `__container_image_version__` from the `gpsw` package to make it available for logging.
  * Added a new `DOCKER_VERSION` variable and updated the logging output to include the Docker image version when the `apptainer` argument is used. [[1]](diffhunk://#diff-86f00377ecaad3452f09e7f03c1c1b73c4a6a78e6064635f02daa9a86d0c024aR24) [[2]](diffhunk://#diff-86f00377ecaad3452f09e7f03c1c1b73c4a6a78e6064635f02daa9a86d0c024aR87-R89)

### Tag Validation Refinement:
* [`src/gpsw/cli.py`](diffhunk://#diff-d129bb287ebbeca3970ae448fa89cf25b59f554b74271ecea4e250a7d07bb21cL34-R37): Updated the tag validation regex to remove the requirement for a leading "v" in version tags. Tags are now expected in the format `X.X.X` instead of `vX.X.X`.

Related to issue #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The Docker image version used by the package is now displayed in workflow logs for improved transparency.
- **Chores**
	- Updated the project version to 0.6.1.
	- Enforced strict release tag formatting to require tags in the format "X.X.X" (e.g., 1.0.0), disallowing any leading "v".
	- Improved package metadata management and versioning integration.
	- Enhanced GitHub Actions workflows with explicit Python 3.12 setup, dependency installation, and environment configuration for better reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->