### PR TITLE
feat: zscores based on median absolute deviation

### DIFF
--- a/docs/zscores.rst
+++ b/docs/zscores.rst
@@ -1,10 +1,11 @@
 z-score calculation
 --------------------------------------------------------------------------------
-With `bin_number` greater than 1, `GPSW` will perform a protein stability analysis using Protein Stability Index (PSI) as a metric. This is calculated as follows:
+
+With `bin_number` greater than 1, `GPSW` will perform a protein stability analysis using Protein Stability Index (PSI, :math:`\Psi`) as a metric. This is calculated as follows:
 
 .. math::
 
-   PSI=\sum_{i=1}^nR_i \times i
+   \Psi=\sum_{i=1}^nR_i \times i
 
 where:
 
@@ -12,23 +13,23 @@ where:
 - :math:`n` is the number of bins.
 - :math:`i` is the bin number.
 
-Between two conditions (test and control), the :math:`\Delta PSI` is calculated as:
+Between two conditions (test and control), the :math:`\Delta\Psi` is calculated as:
 
 .. math::
 
-   \Delta PSI = PSI_{test} - PSI_{control}
+   \Delta\Psi = \Psi_{test} - \Psi_{control}
 
-Next, the :math:`\Delta PSI` is normalized to the mean and standard deviation of the :math:`\Delta PSI` values for all ORFs, resulting in a z-score:
+Next, :math:`\Delta\Psi` is converted to a robust z-score:
 
 .. math::
+   z = \frac{\Delta\Psi_i - \text{median}(\Delta\Psi_j)}{k \times \text{median}(|\Delta\Psi_j - \text{median}(\Delta\Psi_j)|)}
 
-   z = \frac{\Delta PSI - \mu}{\sigma}
 
 where:
 
-- :math:`z` is the z-score.
-- :math:`\mu` is the mean :math:`\Delta PSI` for all ORFs.
-- :math:`\sigma` is the standard deviation of :math:`\Delta PSI` for all ORFs.
+- :math:`\Delta\Psi_i` represents a single :math:`\Delta\Psi` value for a given ORF :math:`i`.
+- :math:`\Delta\Psi_j` represents :math:`\Delta\Psi` values for all ORFs.
+- :math:`k` is a standard scaling constant (:math:`1.4826`). It is approximately :math:`1/(\Phi^{-1}(3/4))`, where :math:`\Phi^{-1}` is the inverse of the cumulative distribution function for a standard normal distribution. 
 
 The z-score of ORFs with a low number of `good barcodes` (see note below) is corrected, as follows:
 
@@ -55,14 +56,14 @@ A final z-score correction is applied to correct for intra-ORF variability:
    z_{c}' = \begin{cases}
    \frac{z_{c}}{\sigma_i} & \text{if } \sigma_i > 0 \\
    \frac{z_{c}}{\epsilon} & \text{if } \sigma_i = 0
-   \end{cases} \times \frac{|\Delta PSI|}{h}
+   \end{cases} \times \frac{|\Delta\Psi|}{h}
 
 Where:
 
 - :math:`z_{c}'` is the final corrected z-score.
-- :math:`\sigma_{i}` is the standard deviation of :math:`\Delta PSI` values of an individual ORF.
-- :math:`h` is a user-defined, absolute, :math:`\Delta PSI` threshold for calling a hit.
-- :math:`|\Delta PSI|` is the absolute value of :math:`\Delta PSI` for the individual ORF.
+- :math:`\sigma_{i}` is the standard deviation of :math:`\Delta\Psi` values of an individual ORF.
+- :math:`h` is a user-defined, absolute, :math:`\Delta\Psi` threshold for calling a hit.
+- :math:`|\Delta\Psi|` is the absolute value of :math:`\Delta\Psi` for the individual ORF.
 - :math:`\epsilon` is the lowest :math:`\sigma_i` of all ORFs (to avoid division by zero).
 
 z-score scaling

--- a/workflow/scripts/calculate_psi.py
+++ b/workflow/scripts/calculate_psi.py
@@ -256,9 +256,15 @@ plt.title("Distribution of delta_PSI_mean")
 plt.savefig(snakemake.output["hist"])
 
 logging.info("Calculating z-scores")
-df["z_score"] = (df["delta_PSI_mean"] - df["delta_PSI_mean"].mean()) / df[
-    "delta_PSI_mean"
-].std()
+# Calculate robust z-score based of median and Median Absolute Deviation (MAD)
+# https://en.wikipedia.org/wiki/Median_absolute_deviation
+# https://en.wikipedia.org/wiki/Robust_measures_of_scale
+mad = abs(df["delta_PSI_mean"] - df["delta_PSI_mean"].median())
+df["z_score"] = (
+    df["delta_PSI_mean"] - df["delta_PSI_mean"].median()
+) / (
+    mad.median() * 1.4826
+)  # 1.4826 is a constant to make MAD comparable to standard deviation
 
 logging.info("Correcting z-scores for number of barcodes")
 # Correct for number of barcodes, but only if good barcode number is less than median


### PR DESCRIPTION
This pull request updates the z-score calculation methodology for protein stability analysis, transitioning from mean-based normalization to a robust median-based approach. It also ensures consistent notation by replacing `PSI` with `\Psi` throughout the documentation and code.

### Documentation updates:

* [`docs/zscores.rst`](diffhunk://#diff-398c3092e8495621d95e9914a459d45e5f8e6d2d5cfc03cd57ab500fd9000381L3-R32): Replaced `PSI` with `\Psi` for consistency in mathematical notation and updated the z-score formula to use median-based normalization with the Median Absolute Deviation (MAD) instead of mean and standard deviation. Added explanation for the scaling constant `k` used in the robust z-score calculation.
* [`docs/zscores.rst`](diffhunk://#diff-398c3092e8495621d95e9914a459d45e5f8e6d2d5cfc03cd57ab500fd9000381L58-R66): Updated the final z-score correction formula to reflect the change in notation from `PSI` to `\Psi`.

### Code updates:

* [`workflow/scripts/calculate_psi.py`](diffhunk://#diff-34363086a338be28e4e79d69cadc2e4e004cf498e4104c7dd10e219ce53b5cfdL259-R267): Modified the z-score calculation to use robust median-based normalization with MAD instead of mean and standard deviation. Included references to MAD and robust measures of scale in comments for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated z-score calculation documentation to use the Greek letter Psi (Ψ) instead of "PSI" and revised all related formulas and explanations for clarity.
  - Clarified the statistical method by describing the use of medians and median absolute deviations in the z-score calculation.

- **Bug Fixes**
  - Improved z-score calculation by switching from mean and standard deviation to a robust method using median and median absolute deviation, enhancing accuracy for outlier-prone data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->