### PR TITLE
fix: more flexibillity for cutadapt -l flag

### DIFF
--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -13,7 +13,7 @@ properties:
       treatment:
         description: Treatment condition
         type: array
-  
+
   bin_number:
     description: Number of bins used for FACS
     type: integer
@@ -34,7 +34,10 @@ properties:
         type: integer
       l:
         description: Shorten reads to a specific length
-        type: integer
+        oneOf:
+          - type: integer
+          - type: string
+            maxLength: 0
       extra:
         description: Extra arguments for cutadapt
         type: string
@@ -104,7 +107,7 @@ properties:
       - extra_mageck_arguments
       - mageck_control_barcodes
       - fdr
-  
+
   drugz:
     description: DrugZ settings
     type: object
@@ -188,7 +191,7 @@ properties:
       - penalty_factor
       - bc_threshold
 
-required: 
+required:
   - bin_number
   - cutadapt
   - csv


### PR DESCRIPTION
This pull request updates the schema for the `l` property in `workflow/schemas/config.schema.yaml` to allow it to accept either an integer or an empty string, in addition to its previous support for integers. This change improves flexibility in how the property can be specified.

- Schema flexibility:
  * Updated the `l` property to accept either an integer or an empty string (via `oneOf`), instead of only an integer. This allows users to indicate an unset or optional value by providing an empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Normalized configuration schema formatting for improved consistency.
  * Enhanced field validation rules to support additional input formats for configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->